### PR TITLE
Switch away to Quay.io and enable vms autostart by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # README: http://makefiletutorial.com
 TARGET_PATH   = /src/app
 VOLUME_PATH   = $(shell pwd):$(TARGET_PATH)
-RUBY_IMAGE    = krates/toolbox:2.6.5-3
+RUBY_IMAGE    = quay.io/krates/toolbox:2.6.5-3
 
 # Adding PHONY to a target will prevent make from confusing the phony target with a file name.
 # In this case, if `test` folder exists, `make test` will still be run.

--- a/lib/kontena/machine/vagrant/Vagrantfile.master.rb.erb
+++ b/lib/kontena/machine/vagrant/Vagrantfile.master.rb.erb
@@ -11,7 +11,6 @@ write_files:
     permissions: 0600
     owner: root
     content: |
-      KONTENA_VERSION=<%= version %>
       KRATES_VAULT_KEY=<%= vault_secret %>
       KRATES_VAULT_IV=<%= vault_iv %>
 coreos:
@@ -69,7 +68,7 @@ coreos:
         ExecStartPre=-/usr/bin/docker stop krates-server-api
         ExecStartPre=-/usr/bin/docker rm krates-server-api
         ExecStartPre=-/usr/bin/docker network create krates
-        ExecStartPre=/usr/bin/docker pull krates/master:${KONTENA_VERSION}
+        ExecStartPre=/usr/bin/docker pull quay.io/krates/master
         ExecStart=/usr/bin/docker run --name krates-server-api \
             -e MONGODB_URI=mongodb://krates-server-mongo:27017/krates_server \
             -e VAULT_KEY=${KRATES_VAULT_KEY} -e VAULT_IV=${KRATES_VAULT_IV} \
@@ -77,7 +76,7 @@ coreos:
             <% if initial_admin_code %>-e INITIAL_ADMIN_CODE=<%= initial_admin_code %><% end %> \
             --network krates \
             -p 8080:9292 \
-            krates/master:${KONTENA_VERSION}
+            quay.io/krates/master
         ExecStop=/usr/bin/docker stop krates-server-api
 INIT
 
@@ -106,6 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.auto_nat_dns_proxy = false
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "off" ]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off" ]
+      vb.customize ["modifyvm", :id, "--autostart-enabled", "on" ]
     end
     docker.vm.provision :file, :source => cloud_init_file.path, :destination => "/tmp/vagrantfile-user-data"
     docker.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true

--- a/lib/kontena/machine/vagrant/Vagrantfile.node.rb.erb
+++ b/lib/kontena/machine/vagrant/Vagrantfile.node.rb.erb
@@ -31,6 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.auto_nat_dns_proxy = false
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "off" ]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off" ]
+      vb.customize ["modifyvm", :id, "--autostart-enabled", "on" ]
     end
     docker.vm.provision :file, :source => "<%= cloudinit %>", :destination => "/tmp/vagrantfile-user-data"
     docker.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true

--- a/lib/kontena/machine/vagrant/cloudinit.yml
+++ b/lib/kontena/machine/vagrant/cloudinit.yml
@@ -7,7 +7,6 @@ write_files:
       KONTENA_URI=<%= master_uri %>
       KONTENA_TOKEN=<%= grid_token %>
       KONTENA_PEER_INTERFACE=eth1
-      KONTENA_VERSION=<%= version %>
   - path: /etc/systemd/system/docker.service.d/50-krates.conf
     content: |
         [Service]
@@ -82,11 +81,11 @@ coreos:
         EnvironmentFile=/etc/krates-worker.env
         ExecStartPre=-/usr/bin/docker stop krates-worker
         ExecStartPre=-/usr/bin/docker rm krates-worker
-        ExecStartPre=/usr/bin/docker pull krates/worker
+        ExecStartPre=/usr/bin/docker pull quay.io/krates/worker
         ExecStart=/usr/bin/docker run --name krates-worker \
             --env-file /etc/krates-worker.env \
             -v=/var/run/docker.sock:/var/run/docker.sock \
             -v=/etc/krates-worker.env:/etc/kontena.env \
             --net=host \
-            krates/worker
+            quay.io/krates/worker
         ExecStop=/usr/bin/docker stop krates-worker

--- a/lib/kontena/plugin/vagrant.rb
+++ b/lib/kontena/plugin/vagrant.rb
@@ -1,7 +1,7 @@
 module Kontena
   module Plugin
     module Vagrant
-      VERSION = "0.3.5"
+      VERSION = "0.3.6"
     end
   end
 end


### PR DESCRIPTION
 - Quay: Switch away from Docker Hub to avoid issues with rate limiting
 - VirtualBox: By default set '--autostart-enabled on' option for Master and Worker vms